### PR TITLE
Improved logging macro and cleaned existing call to said macro

### DIFF
--- a/cubic-server/Chat.cpp
+++ b/cubic-server/Chat.cpp
@@ -7,7 +7,6 @@
 
 Chat::Chat()
 {
-    _log = logging::Logger::get_instance();
 }
 
 void Chat::sendPlayerMessage(const chat::Message &message, const Player *sender)
@@ -53,7 +52,7 @@ void Chat::sendSystemMessage(const chat::Message &message, bool overlay, const W
         LERROR("worldGroup is null");
         return;
     }
-    LDEBUG("send System Message: " + message.getMessage()); // FUCKING CRASHES THE SERVER BECAUSE I DON'T FUCKING KNOW
+    LDEBUG("send System Message: ", message.getMessage()); // FUCKING CRASHES THE SERVER BECAUSE I DON'T FUCKING KNOW
 
     // TODO: Filter client by chat visibility
     for (const auto &world : worldGroup->getWorlds()) {
@@ -228,7 +227,7 @@ nlohmann::json chat::message::ClickEvent::toJson() const
         case Action::CopyToClipboard:
             response["action"] = "copy_to_clipboard"; break;
         default:
-            LERROR("Unknown click event action: " + std::to_string((int32_t) action)); break;
+            LERROR("Unknown click event action: ", static_cast<int32_t>(action)); break;
     }
 
     response["value"] = value;
@@ -248,7 +247,7 @@ nlohmann::json chat::message::HoverEvent::toJson() const
         case Action::ShowEntity:
             response["action"] = "show_entity"; break;
         default:
-            LERROR("Unknown hover event action: " + std::to_string((int32_t) action)); break;
+            LERROR("Unknown hover event action: ", static_cast<int32_t>(action)); break;
     }
 
     response["contents"] == value;

--- a/cubic-server/Chat.hpp
+++ b/cubic-server/Chat.hpp
@@ -37,7 +37,7 @@ namespace chat::message {
 
     public:
         ClickEvent(Action action, const std::string &value)
-            : action(action), value(value), _log(logging::Logger::get_instance())
+            : action(action), value(value)
         {}
         nlohmann::json toJson() const;
 
@@ -47,7 +47,6 @@ namespace chat::message {
     private:
         Action action;
         std::string value;
-        logging::Logger *_log;
     };
 
     class HoverEvent {
@@ -63,7 +62,7 @@ namespace chat::message {
 
     public:
         HoverEvent(Action action, const std::string &value)
-            : action(action), value(value), _log(logging::Logger::get_instance())
+            : action(action), value(value)
         {};
         nlohmann::json toJson() const;
 
@@ -73,7 +72,6 @@ namespace chat::message {
     private:
         Action action;
         std::string value;
-        logging::Logger *_log;
     };
 }
 
@@ -155,7 +153,6 @@ public:
 
 private:
     std::unordered_map<chat::message::Type, chat::Message> _messagesLog;
-    logging::Logger *_log;
 };
 
 #endif //CUBICSERVER_CHAT_HPP

--- a/cubic-server/Client.cpp
+++ b/cubic-server/Client.cpp
@@ -22,8 +22,7 @@ Client::Client(int sockfd, struct sockaddr_in6 addr):
     _send_buffer(0),
     _networkThread(&Client::networkLoop, this),
     _player(nullptr),
-    _is_running(true),
-    _log(logging::Logger::get_instance())
+    _is_running(true)
 {
 }
 
@@ -65,7 +64,7 @@ void Client::networkLoop()
         {
             int read_size = read(_sockfd, in_buffer, 2048);
             if (read_size == -1)
-                LERROR("Read error" + std::string(strerror(errno)));
+                LERROR("Read error", strerror(errno));
             else if (read_size == 0)
                 break;
             else
@@ -107,7 +106,7 @@ void Client::_flushSendData()
 
     ssize_t write_return = write(_sockfd, send_buffer, to_send);
     if (write_return == -1)
-        LERROR("Write error" + std::string(strerror(errno)));
+        LERROR("Write error", strerror(errno));
 
     if (write_return <= 0) {
         _write_mutex.unlock();
@@ -233,8 +232,8 @@ void Client::handleParsedClientPacket(const std::shared_ptr<protocol::BaseServer
         }
         break;
     }
-    LERROR("Unhandled packet: " + std::to_string(static_cast<int>(packetID)) +
-        " in status " + std::to_string(static_cast<int>(_status))); // TODO: Properly handle the unknown packet
+    LERROR("Unhandled packet: ", static_cast<int>(packetID) +
+        " in status ", static_cast<int>(_status)); // TODO: Properly handle the unknown packet
 }
 
 void Client::_handlePacket()
@@ -281,7 +280,7 @@ void Client::_handlePacket()
         std::vector<uint8_t> to_parse(data.begin() + (at - data.data()), data.end());
         data.erase(data.begin(), data.begin() + (start_payload - data.data()) + length);
         if (error) {
-            LWARN("Unhandled packet: " + std::to_string(static_cast<int>(packet_id)) + " in status " + std::to_string(static_cast<int>(_status)));
+            LWARN("Unhandled packet: ", static_cast<int>(packet_id), " in status ", static_cast<int>(_status));
             return;
         }
         std::shared_ptr<protocol::BaseServerPacket> packet;
@@ -289,8 +288,7 @@ void Client::_handlePacket()
             packet = parser(to_parse);
         }
         catch (std::runtime_error &error) {
-            LERROR("Error during packet parsing :");
-            LERROR(error.what());
+            LERROR("Error during packet parsing :", std::endl, error.what());
             return;
         }
         // Callback to handle the packet
@@ -378,7 +376,7 @@ void Client::_onLoginStart(const std::shared_ptr<protocol::LoginStart> &pck)
 
 void Client::_onEncryptionResponse(const std::shared_ptr<protocol::EncryptionResponse> &pck)
 {
-    _log->debug("Got a Encryption Response");
+    LDEBUG("Got a Encryption Response");
 }
 
 void Client::sendStatusResponse(const std::string &json)

--- a/cubic-server/Client.cpp
+++ b/cubic-server/Client.cpp
@@ -288,7 +288,8 @@ void Client::_handlePacket()
             packet = parser(to_parse);
         }
         catch (std::runtime_error &error) {
-            LERROR("Error during packet parsing :", std::endl, error.what());
+            LERROR("Error during packet parsing :");
+            LERROR(error.what());
             return;
         }
         // Callback to handle the packet

--- a/cubic-server/Client.hpp
+++ b/cubic-server/Client.hpp
@@ -94,7 +94,6 @@ private:
     std::vector<uint8_t> _send_buffer;
     std::thread _networkThread;
     Player *_player;
-    logging::Logger *_log;
     std::mutex _write_mutex;
 };
 

--- a/cubic-server/Dimension.cpp
+++ b/cubic-server/Dimension.cpp
@@ -10,7 +10,6 @@ Dimension::Dimension(World *world):
     _dimensionLock(std::counting_semaphore<1000>(0)),
     _isInitialized(false)
 {
-    _log = logging::Logger::get_instance();
 }
 
 void Dimension::tick()
@@ -211,8 +210,8 @@ void Dimension::spawnPlayer(Player *current)
     const std::vector<Player *> player_list = this->getPlayerList();
 
     for (auto &player : player_list) {
-        LDEBUG("player is : " + player->getUsername());
-        LDEBUG("current is : " + current->getUsername());
+        LDEBUG("player is : ", player->getUsername());
+        LDEBUG("current is : ", current->getUsername());
         //if (current->getPos().distance(player->getPos()) <= 12) {
         if (player->getId() != current->getId()) {
             player->sendSpawnPlayer({
@@ -224,7 +223,7 @@ void Dimension::spawnPlayer(Player *current)
                 current->getRotation().x,
                 current->getRotation().y
             });
-            LDEBUG("send spawn player to " + player->getUsername());
+            LDEBUG("send spawn player to ", player->getUsername());
             current->sendSpawnPlayer({
                 player->getId(),
                 player->getUuid(),
@@ -234,7 +233,7 @@ void Dimension::spawnPlayer(Player *current)
                 player->getRotation().x,
                 player->getRotation().y
             });
-            LDEBUG("send spawn player to " + current->getUsername());
+            LDEBUG("send spawn player to ", current->getUsername());
         //}
         }
     }
@@ -242,7 +241,7 @@ void Dimension::spawnPlayer(Player *current)
 
 void Dimension::blockUpdate(Position position, int32_t id)
 {
-    LINFO("Dimension block update (" + std::to_string(position.x) + ", " + std::to_string(position.y) + ", " + std::to_string(position.z) + ") -> " + std::to_string(id) + ")");
+    LINFO("Dimension block update ", position, " -> ", id, ")");
     auto &chunk = this->_level.getChunkColumnFromBlockPos(position.x, position.z);
 
     // Weird ass modulo to get the correct block position in the chunk

--- a/cubic-server/Dimension.hpp
+++ b/cubic-server/Dimension.hpp
@@ -101,7 +101,6 @@ protected:
 protected:
     std::counting_semaphore<SEMAPHORE_MAX> _dimensionLock;
     std::vector<Entity *> _entities;
-    logging::Logger *_log;
     World *_world;
     std::mutex _processingMutex;
     std::atomic<bool> _isInitialized;

--- a/cubic-server/Player.cpp
+++ b/cubic-server/Player.cpp
@@ -20,7 +20,6 @@ Player::Player(Client *cli, std::shared_ptr<Dimension> dim, u128 uuid, const std
     _gamemode(0),
     _keepAliveClock(200, std::bind(&Player::_processKeepAlive, this)) // 5 seconds for keep-alives
 {
-    _log = logging::Logger::get_instance();
     _keepAliveClock.start();
     _heldItem = 0;
 
@@ -342,7 +341,7 @@ void Player::sendBlockUpdate(const protocol::BlockUpdate &packet)
     auto pck = protocol::createBlockUpdate(packet);
     this->_cli->_sendData(*pck);
 
-    LINFO("Sent a block update at (" + std::to_string(packet.location.x) + ", " + std::to_string(packet.location.y) + ", " + std::to_string(packet.location.z) + ") = " + std::to_string(packet.block_id) + " to " + this->getUsername());
+    LINFO("Sent a block update at ", packet.location, " = ", packet.block_id, " to ", this->getUsername());
 }
 
 void Player::sendLoginPlay(const protocol::LoginPlay &packet)
@@ -403,7 +402,7 @@ void Player::sendLoginPlay(const protocol::LoginPlay &packet)
 
 void Player::sendPlayerInfo(const protocol::PlayerInfo &data)
 {
-    LDEBUG("Sending PlayerInfo. Currently there is: " + std::to_string(data.numberOfPlayers) + " players");
+    LDEBUG("Sending PlayerInfo. Currently there is: ", data.numberOfPlayers, " players");
     auto pck = protocol::createPlayerInfo(data);
     this->_cli->_sendData(*pck);
 
@@ -415,7 +414,7 @@ void Player::sendSpawnPlayer(const protocol::SpawnPlayer &data)
     auto pck = protocol::createSpawnPlayer(data);
     this->_cli->_sendData(*pck);
 
-    LDEBUG("Sent a Spawn Player packet on coords: " + std::to_string(data.x) + " " + std::to_string(data.y) + " " + std::to_string(data.z));
+    LDEBUG("Sent a Spawn Player packet on coords: ", data.x, " ", data.y, " ", data.z);
 }
 
 void Player::sendUpdateTime(const protocol::UpdateTime &data)
@@ -595,7 +594,7 @@ void Player::sendChunkAndLightUpdate(const world_storage::ChunkColumn &chunk)
 
     this->_chunks[chunkPos] = ChunkState::Loaded;
 
-    logging::Logger::get_instance()->debug("Sent a chunk data and light update packet (" + std::to_string(chunkPos.x) + ", " + std::to_string(chunkPos.z) + ")");
+    LDEBUG("Sent a chunk data and light update packet ", chunkPos, ")");
     delete motionBlockingList;
     delete worldSurfaceList;
 }
@@ -613,7 +612,7 @@ void Player::sendUnloadChunk(int32_t x, int32_t z)
     auto pck = protocol::createUnloadChunk({x, z});
     this->_cli->_sendData(*pck);
     this->_chunks.erase({x, z});
-    LDEBUG("Sent an unload chunk packet (" + std::to_string(x) + ", " + std::to_string(z) + ")");
+    LDEBUG("Sent an unload chunk packet (", x, ", ", z, ")");
 }
 
 void Player::sendRemoveEntities(const std::vector<int32_t> &entities)
@@ -674,7 +673,7 @@ void Player::_onChatMessage(const std::shared_ptr<protocol::ChatMessage> &pck)
 {
     // TODO: verify that the message is valid (signature, etc.)
     _dim->getWorld()->getChat()->sendPlayerMessage(pck->message, this);
-    _log->debug("Got a Chat Message");
+    LDEBUG("Got a Chat Message");
 }
 
 void Player::_onClientCommand(const std::shared_ptr<protocol::ClientCommand> &pck)
@@ -820,7 +819,7 @@ void Player::_onPlayerAbilities(const std::shared_ptr<protocol::PlayerAbilities>
 void Player::_onPlayerAction(const std::shared_ptr<protocol::PlayerAction> &pck)
 {
     // LINFO("Got a Player Action " + std::to_string(pck->status) + " at (" + std::to_string(pck->location.x) + ", " + std::to_string(pck->location.y) + ", " + std::to_string(pck->location.z) + ")");
-    LDEBUG("Got a Player Action and player is in gamemode " + std::to_string(this->getGamemode()) + " and status is " + std::to_string(pck->status));
+    LDEBUG("Got a Player Action and player is in gamemode ", this->getGamemode(), " and status is ", pck->status);
     if (pck->status == 0 && this->getGamemode() == 1) {
         this->getDimension()->blockUpdate(pck->location, 0);
     } else if (pck->status == 2) {
@@ -926,7 +925,7 @@ void Player::_onTeleportToEntity(const std::shared_ptr<protocol::TeleportToEntit
 
 void Player::_onUseItemOn(const std::shared_ptr<protocol::UseItemOn> &pck)
 {
-    LDEBUG("Got a Use Item On (" + std::to_string(pck->location.x) + ", " + std::to_string(pck->location.y) + ", " + std::to_string(pck->location.z) + ") -> " + std::to_string(this->_heldItem));
+    LDEBUG("Got a Use Item On ", pck->location, " -> ", this->_heldItem);
     switch (pck->face)
     {
         case 0: pck->location.y--; break;

--- a/cubic-server/Player.cpp
+++ b/cubic-server/Player.cpp
@@ -738,7 +738,7 @@ void Player::_onJigsawGenerate(const std::shared_ptr<protocol::JigsawGenerate> &
 void Player::_onKeepAliveResponse(const std::shared_ptr<protocol::KeepAliveResponse> &pck)
 {
     if (pck->keep_alive_id != _keepAliveId) {
-        LERROR("Got a Keep Alive Response with a wrong ID: " + std::to_string(pck->keep_alive_id) + " (expected " + std::to_string(_keepAliveId) + ")");
+        LERROR("Got a Keep Alive Response with a wrong ID: ", pck->keep_alive_id, " (expected ",_keepAliveId, ")");
         this->disconnect("Wrong Keep Alive ID");
         return;
     }
@@ -754,14 +754,14 @@ void Player::_onLockDifficulty(const std::shared_ptr<protocol::LockDifficulty> &
 
 void Player::_onSetPlayerPosition(const std::shared_ptr<protocol::SetPlayerPosition> &pck)
 {
-    LDEBUG("Got a Set Player Position (" + std::to_string(pck->x) + ", " + std::to_string(pck->feet_y) + ", " + std::to_string(pck->z) + ")");
+    LDEBUG("Got a Set Player Position (", pck->x, ", ", pck->feet_y, ", ", pck->z, ")");
     // TODO: Validate the position
     this->setPosition(pck->x, pck->feet_y, pck->z);
 }
 
 void Player::_onSetPlayerPositionAndRotation(const std::shared_ptr<protocol::SetPlayerPositionAndRotation> &pck)
 {
-    LDEBUG("Got a Set Player Position And Rotation (" + std::to_string(pck->x) + ", " + std::to_string(pck->feet_y) + ", " + std::to_string(pck->z) + ")");
+    LDEBUG("Got a Set Player Position And Rotation (", pck->x, ", ", pck->feet_y, ", ", pck->z, ")");
     // TODO: Validate the position
     this->setPosition(pck->x, pck->feet_y, pck->z);
     float yaw_tmp = pck->yaw;
@@ -818,7 +818,7 @@ void Player::_onPlayerAbilities(const std::shared_ptr<protocol::PlayerAbilities>
 
 void Player::_onPlayerAction(const std::shared_ptr<protocol::PlayerAction> &pck)
 {
-    // LINFO("Got a Player Action " + std::to_string(pck->status) + " at (" + std::to_string(pck->location.x) + ", " + std::to_string(pck->location.y) + ", " + std::to_string(pck->location.z) + ")");
+    // LINFO("Got a Player Action ", pck->status, " at ", pck->location);
     LDEBUG("Got a Player Action and player is in gamemode ", this->getGamemode(), " and status is ", pck->status);
     if (pck->status == 0 && this->getGamemode() == 1) {
         this->getDimension()->blockUpdate(pck->location, 0);

--- a/cubic-server/Player.hpp
+++ b/cubic-server/Player.hpp
@@ -129,7 +129,6 @@ private:
 private:
     void _processKeepAlive();
 
-    logging::Logger *_log;
     Client *_cli;
     std::string _username;
     std::string _uuidString;

--- a/cubic-server/Server.cpp
+++ b/cubic-server/Server.cpp
@@ -32,8 +32,7 @@ Server::Server():
     _motd = _config.getMotd();
     _enforceWhitelist = _config.getEnforceWhitelist();
 
-    _log = logging::Logger::get_instance();
-    LINFO("Server created with host: " + _host + " and port: " + std::to_string(_port));
+    LINFO("Server created with host: ", _host, " and port: ", _port);
 }
 
 Server::~Server()

--- a/cubic-server/Server.hpp
+++ b/cubic-server/Server.hpp
@@ -81,8 +81,6 @@ private:
     bool _enforceWhitelist;
     std::atomic<bool> _running;
 
-    logging::Logger *_log;
-
     // Looks like it is thread-safe, if something breaks it is here
     std::vector<std::shared_ptr<Client>> _clients;
 

--- a/cubic-server/World.cpp
+++ b/cubic-server/World.cpp
@@ -13,7 +13,6 @@ World::World(WorldGroup *worldGroup):
     _timeUpdateClock(20, std::bind(&World::updateTime, this)), // 1 second for time updates
     _generationPool(16, "WorldGen", thread_pool::Pool::Behavior::Cancel)
 {
-    _log = logging::Logger::get_instance();
     _timeUpdateClock.start();
     _seed = -721274728; // TODO: Should be loaded from config or generated
     _chat = worldGroup->getChat();
@@ -177,7 +176,7 @@ void World::sendPlayerInfoAddPlayer(Player *current) {
         .numberOfPlayers = (int32_t) players.size(),
         .players = players_info
     });
-    LDEBUG("Sent player info to " + current->getUsername());
+    LDEBUG("Sent player info to ", current->getUsername());
 }
 
 void World::sendPlayerInfoRemovePlayer(Player *current) {
@@ -203,7 +202,7 @@ void World::sendPlayerInfoRemovePlayer(Player *current) {
             });
         }
     }
-    LDEBUG("Sent player info to " + current->getUsername());
+    LDEBUG("Sent player info to ", current->getUsername());
 }
 
 thread_pool::Pool &World::getGenerationPool()

--- a/cubic-server/World.hpp
+++ b/cubic-server/World.hpp
@@ -52,7 +52,6 @@ public:
 protected:
     std::shared_ptr<Chat> _chat;
     WorldGroup *_worldGroup;
-    logging::Logger *_log;
     std::unordered_map<std::string_view, std::shared_ptr<Dimension>> _dimensions;
     long _age;
     long _time;

--- a/cubic-server/WorldGroup.cpp
+++ b/cubic-server/WorldGroup.cpp
@@ -12,7 +12,6 @@ WorldGroup::WorldGroup(std::shared_ptr<Chat> chat):
     _soundSystem(new SoundSystem(this)),
     _running(true)
 {
-    _log = logging::Logger::get_instance();
 }
 
 WorldGroup::~WorldGroup()
@@ -38,7 +37,7 @@ void WorldGroup::_run()
         auto compute_time = end_time - start_time;
         if (compute_time > std::chrono::milliseconds(MS_PER_TICK)) {// If this happens there is a serious problem
             auto nb_ticks = compute_time / std::chrono::milliseconds(MS_PER_TICK);
-            LWARN("Can't keep up! Did the system time change, or is the server overloaded? Running " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(compute_time).count()) + "ms behind, skipping " + std::to_string(nb_ticks) + " tick(s)");
+            LWARN("Can't keep up! Did the system time change, or is the server overloaded? Running ", std::chrono::duration_cast<std::chrono::milliseconds>(compute_time).count(), "ms behind, skipping ", nb_ticks, " tick(s)");
             continue;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(MS_PER_TICK) - compute_time);

--- a/cubic-server/WorldGroup.hpp
+++ b/cubic-server/WorldGroup.hpp
@@ -31,7 +31,6 @@ protected:
 protected:
     std::shared_ptr<Chat> _chat;
     std::unordered_map<std::string_view, std::shared_ptr<World>> _worlds;
-    logging::Logger *_log;
     SoundSystem *_soundSystem;
     std::atomic<bool> _running;
     std::thread _thread;

--- a/cubic-server/command_parser/CommandParser.cpp
+++ b/cubic-server/command_parser/CommandParser.cpp
@@ -26,7 +26,7 @@ void command_parser::parseCommand(std::string &command) {
     if (result != Server::getInstance()->getCommands().end())
         (*result)->execute(args);
     else {
-        logging::Logger::get_instance()->info("Unknown or incomplete command, see below for error");
-        logging::Logger::get_instance()->info(commandName.erase(commandName.find_last_not_of(' ') + 1) + "<--[HERE]");
+        LINFO("Unknown or incomplete command, see below for error");
+        LINFO(commandName.erase(commandName.find_last_not_of(' ') + 1) + "<--[HERE]");
     }
 }

--- a/cubic-server/command_parser/commands/Help.cpp
+++ b/cubic-server/command_parser/commands/Help.cpp
@@ -4,13 +4,13 @@
 using namespace command_parser;
 
 void Help::autocomplete(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("autocomplete help");
+    LINFO("autocomplete help");
 }
 
 void Help::execute(std::vector<std::string>& args) const {
     if (args.empty()) {
         for (auto command : Server::getInstance()->getCommands()) {
-            logging::Logger::get_instance()->info(command->_help);
+            LINFO(command->_help);
         }
     }
     else {
@@ -24,10 +24,10 @@ void Help::execute(std::vector<std::string>& args) const {
         if (result != Server::getInstance()->getCommands().end())
             (*result)->help(args);
         else
-            logging::Logger::get_instance()->info("Unknown command or insufficient permissions");
+            LINFO("Unknown command or insufficient permissions");
     }
 }
 
 void Help::help(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("/help [<command>]");
+    LINFO("/help [<command>]");
 }

--- a/cubic-server/command_parser/commands/QuestionMark.cpp
+++ b/cubic-server/command_parser/commands/QuestionMark.cpp
@@ -4,13 +4,13 @@
 using namespace command_parser;
 
 void QuestionMark::autocomplete(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("autocomplete ?");
+    LINFO("autocomplete ?");
 }
 
 void QuestionMark::execute(std::vector<std::string>& args) const {
     if (args.empty()) {
         for (auto command : Server::getInstance()->getCommands()) {
-            logging::Logger::get_instance()->info(command->_help);
+            LINFO(command->_help);
         }
     }
     else {
@@ -24,10 +24,10 @@ void QuestionMark::execute(std::vector<std::string>& args) const {
         if (result != Server::getInstance()->getCommands().end())
             (*result)->help(args);
         else
-            logging::Logger::get_instance()->info("Unknown command or insufficient permissions");
+            LINFO("Unknown command or insufficient permissions");
     }
 }
 
 void QuestionMark::help(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("/? [<command>]");
+    LINFO("/? [<command>]");
 }

--- a/cubic-server/command_parser/commands/Seed.cpp
+++ b/cubic-server/command_parser/commands/Seed.cpp
@@ -3,14 +3,14 @@
 #include "World.hpp"
 
 void command_parser::Seed::autocomplete(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("autocomplete seed");
+    LINFO("autocomplete seed");
 }
 
 void command_parser::Seed::execute(std::vector<std::string>& args) const {
     std::string msg = "Seed: [" + std::to_string(Server::getInstance()->getWorldGroup("default")->getWorld("default")->getSeed()) + "]";
-    logging::Logger::get_instance()->info(msg);
+    LINFO(msg);
 }
 
 void command_parser::Seed::help(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("/seed");
+    LINFO("/seed");
 }

--- a/cubic-server/command_parser/commands/Seed.cpp
+++ b/cubic-server/command_parser/commands/Seed.cpp
@@ -7,8 +7,7 @@ void command_parser::Seed::autocomplete(std::vector<std::string>& args) const {
 }
 
 void command_parser::Seed::execute(std::vector<std::string>& args) const {
-    std::string msg = "Seed: [" + std::to_string(Server::getInstance()->getWorldGroup("default")->getWorld("default")->getSeed()) + "]";
-    LINFO(msg);
+    LINFO("Seed: [", Server::getInstance()->getWorldGroup("default")->getWorld("default")->getSeed(), "]");
 }
 
 void command_parser::Seed::help(std::vector<std::string>& args) const {

--- a/cubic-server/command_parser/commands/Stop.cpp
+++ b/cubic-server/command_parser/commands/Stop.cpp
@@ -4,7 +4,7 @@
 using namespace command_parser;
 
 void Stop::autocomplete(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("autocomplete stop");
+    LINFO("autocomplete stop");
 }
 
 void Stop::execute(std::vector<std::string>& args) const {
@@ -12,5 +12,5 @@ void Stop::execute(std::vector<std::string>& args) const {
 }
 
 void Stop::help(std::vector<std::string>& args) const {
-    logging::Logger::get_instance()->info("/stop");
+    LINFO("/stop");
 }

--- a/cubic-server/concept.hpp
+++ b/cubic-server/concept.hpp
@@ -3,6 +3,12 @@
 
 #include "nbt.hpp"
 
+template <typename T>
+concept Streamable =
+requires(std::ostream &os, const T &value) {
+{ os << value } -> std::convertible_to<std::ostream &>;
+};
+
 template<typename T>
 concept is_nbt = std::is_base_of_v<nbt::Base, T>;
 

--- a/cubic-server/configuration/CMakeLists.txt
+++ b/cubic-server/configuration/CMakeLists.txt
@@ -1,8 +1,10 @@
 # Create a library called "Hello" which includes the source file "hello.cxx".
 # The extension is already found. Any number of sources could be listed here.
-target_sources (${CMAKE_PROJECT_NAME} PRIVATE
-        ConfigHandler.cpp
-        ConfigHandler.hpp)
+target_sources (
+    ${CMAKE_PROJECT_NAME} PRIVATE
+    ConfigHandler.cpp
+    ConfigHandler.hpp
+)
 
 include(FetchContent)
 

--- a/cubic-server/configuration/ConfigHandler.cpp
+++ b/cubic-server/configuration/ConfigHandler.cpp
@@ -27,7 +27,6 @@ general:\n\
 
     ConfigHandler::ConfigHandler()
     {
-        _log = logging::Logger::get_instance();
     }
 
     void ConfigHandler::parse(const std::string &path) {
@@ -42,8 +41,7 @@ general:\n\
             _enforceWhitelist = _baseNode["general"]["enforce-whitelist"].as<bool>();
         }
         catch (const std::exception &e) {
-            LERROR("Config parsing failed, exiting now!");
-            LERROR(e.what());
+            LERROR("Config parsing failed, exiting now!" << std::endl << e.what());
             exit(1); // TODO: Use an exception
         }
     }

--- a/cubic-server/configuration/ConfigHandler.hpp
+++ b/cubic-server/configuration/ConfigHandler.hpp
@@ -31,8 +31,6 @@ namespace Configuration
         uint32_t _maxPlayers;
         std::string _motd;
         bool _enforceWhitelist;
-
-        logging::Logger *_log;
     };
 }
 

--- a/cubic-server/default/Overworld.cpp
+++ b/cubic-server/default/Overworld.cpp
@@ -48,8 +48,8 @@ void Overworld::stop()
 
 void Overworld::generateChunk(int x, int z)
 {
-    LDEBUG("Generate - Overworld (" + std::to_string(x) + ", " + std::to_string(z) + ")");
+    LDEBUG("Generate - Overworld (", x, ", ", z, ")");
     Position2D pos{x, z};
     _level.addChunkColumn(pos).generate(world_storage::WorldType::NORMAL, this->getWorld()->getSeed());
-    LINFO("Chunk generated (" + std::to_string(x) + ", " + std::to_string(z) + ")");
+    LINFO("Chunk generated (", x, ", ", z, ")");
 }

--- a/cubic-server/generation/overworld.cpp
+++ b/cubic-server/generation/overworld.cpp
@@ -23,7 +23,7 @@ GlobalBlockId generation::Overworld::getBlock(position_type x, position_type y, 
     //     ? ((y - world_storage::CHUNK_HEIGHT_MIN) / (heightOffset - (double) world_storage::CHUNK_HEIGHT_MIN)) / 100.0
     //     : ((y - world_storage::CHUNK_HEIGHT_MIN) / ((double) world_storage::CHUNK_HEIGHT_MAX - heightOffset)) / 100.0;
 
-    // // logging::Logger::get_instance()->info(std::to_string(densityMultiplier));
+    // // LINFO(std::to_string(densityMultiplier));
 
     // // double densityMultiplier = std::tanh(y / 384) + heightOffset;
 

--- a/cubic-server/logging/Logger.cpp
+++ b/cubic-server/logging/Logger.cpp
@@ -1,7 +1,8 @@
-#include "Logger.hpp"
-#include "TimeFormatter.hpp"
 #include <iostream>
 #include <algorithm>
+
+#include "Logger.hpp"
+#include "TimeFormatter.hpp"
 
 namespace logging
 {

--- a/cubic-server/logging/Logger.hpp
+++ b/cubic-server/logging/Logger.hpp
@@ -10,7 +10,6 @@
 #include <chrono>
 
 #include "FileAndFolderHandler.hpp"
-#include "concept.hpp"
 
 #define _GET_NTH_ARG(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
 

--- a/cubic-server/logging/Logger.hpp
+++ b/cubic-server/logging/Logger.hpp
@@ -67,12 +67,12 @@ namespace logging
     class LogMessage
     {
     public:
-            LogMessage(LogLevel level, std::string message);
+        LogMessage(LogLevel level, std::string message);
 
-            const LogLevel& get_level() const;
-            const std::string& get_message() const;
-            const std::time_t& get_time() const;
-            const int get_millis() const;
+        const LogLevel& get_level() const;
+        const std::string& get_message() const;
+        const std::time_t& get_time() const;
+        const int get_millis() const;
 
     private:
         const LogLevel _level;

--- a/cubic-server/logging/Logger.hpp
+++ b/cubic-server/logging/Logger.hpp
@@ -10,12 +10,47 @@
 #include <chrono>
 
 #include "FileAndFolderHandler.hpp"
+#include "concept.hpp"
 
-#define LDEBUG(msg) _log->debug(msg)
-#define LINFO(msg) _log->info(msg)
-#define LWARN(msg) _log->warn(msg)
-#define LERROR(msg) _log->error(msg)
-#define LFATAL(msg) _log->fatal(msg)
+#define _GET_NTH_ARG(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
+
+#define _LOG0() __FILE__ << ":" << __LINE__ << " Log called without arguments !"
+#define _LOG1(msg) msg
+#define _LOG2(msg, ...) msg << _LOG1(__VA_ARGS__)
+#define _LOG3(msg, ...) msg << _LOG2(__VA_ARGS__)
+#define _LOG4(msg, ...) msg << _LOG3(__VA_ARGS__)
+#define _LOG5(msg, ...) msg << _LOG4(__VA_ARGS__)
+#define _LOG6(msg, ...) msg << _LOG5(__VA_ARGS__)
+#define _LOG7(msg, ...) msg << _LOG6(__VA_ARGS__)
+#define _LOG8(msg, ...) msg << _LOG7(__VA_ARGS__)
+#define _LOG9(msg, ...) msg << _LOG8(__VA_ARGS__)
+
+#define _LOGN(...) \
+_GET_NTH_ARG( \
+    ,##__VA_ARGS__, \
+    _LOG9(__VA_ARGS__), \
+    _LOG8(__VA_ARGS__), \
+    _LOG7(__VA_ARGS__), \
+    _LOG6(__VA_ARGS__), \
+    _LOG5(__VA_ARGS__), \
+    _LOG4(__VA_ARGS__), \
+    _LOG3(__VA_ARGS__), \
+    _LOG2(__VA_ARGS__), \
+    _LOG1(__VA_ARGS__), \
+    _LOG0(__VA_ARGS__), \
+)
+
+#define _LOG(type, ...) do { \
+    std::stringstream __ss; \
+    __ss << _LOGN(__VA_ARGS__); \
+    ::logging::Logger::get_instance()->type(__ss.str()); \
+} while (0)
+
+#define LDEBUG(...) _LOG(debug, __VA_ARGS__)
+#define LINFO(...) _LOG(info, __VA_ARGS__)
+#define LWARN(...) _LOG(warn, __VA_ARGS__)
+#define LERROR(...) _LOG(error, __VA_ARGS__)
+#define LFATAL(...) _LOG(fatal, __VA_ARGS__)
 
 namespace logging
 {
@@ -67,13 +102,9 @@ namespace logging
         ~Logger();;
 
         void debug(const std::string &msg);
-
         void info(const std::string &msg);
-
         void warn(const std::string &msg);
-
         void error(const std::string &msg);
-
         void fatal(const std::string &msg);
 
         void set_display_specification_level_in_file(LogLevel level);
@@ -88,22 +119,31 @@ namespace logging
         void set_log_buffer_size(int size);
 
     private:
-        Logger();                                                                   /// Private constructor to prevent multiple instances
+        // Private constructor to prevent multiple instances
+        Logger();
         Logger(const Logger&) = delete;
         Logger& operator=(const Logger&) = delete;
         Logger(Logger&&) = delete;
         Logger& operator=(Logger&&) = delete;
+
         std::string get_file_path() const;
 
-        std::fstream _file_stream;                                                  /// Stream to the current log file
-        FileAndFolderHandler _file_and_folder_handler;                              /// Handler for files and folders
+        // Stream to the current log file
+        std::fstream _file_stream;
 
-        std::unordered_map<LogLevel, std::string> _specification_level_in_file;     /// Map of LogLevel and his associated string to display in the log file
-        std::unordered_map<LogLevel, std::string> _specification_level_in_console;  /// Map of LogLevel and his associated string to display in the console
+        // Handler for files and folders
+        FileAndFolderHandler _file_and_folder_handler;
+
+        // Map of LogLevel and his associated string to display in the log file
+        std::unordered_map<LogLevel, std::string> _specification_level_in_file;
+
+        // Map of LogLevel and his associated string to display in the console
+        std::unordered_map<LogLevel, std::string> _specification_level_in_console;
 
         void _log(LogLevel level, const std::string &message);
 
-        std::queue<LogMessage> _log_buffer;                                         /// Buffer to store logs before the file is opened
+        // Buffer to store logs before the file is opened
+        std::queue<LogMessage> _log_buffer;
         int _buffer_size;
 
         std::mutex _loggerMutex;

--- a/cubic-server/types.cpp
+++ b/cubic-server/types.cpp
@@ -1,6 +1,16 @@
 #include "types.hpp"
 
-std::ostream &Position::operator<<(std::ostream &os) const
+std::ostream &operator<<(std::ostream &os, const Position &pos)
 {
-    return os << "Position(" << x << ", " << y << ", " << z << ")";
+    return os << "Position(" << pos.x << ", " << pos.y << ", " << pos.z << ")";
+}
+
+std::ostream &operator<<(std::ostream &os, const Position2D &pos)
+{
+    return os << "Position2D(" << pos.x << ", " << pos.z << ")";
+}
+
+std::ostream &operator<<(std::ostream &os, const Rotation &rot)
+{
+    return os << "Rotation(yaw: " << rot.yaw << ", pitch: " << rot.pitch << ")";
 }

--- a/cubic-server/types.hpp
+++ b/cubic-server/types.hpp
@@ -3,9 +3,7 @@
 
 #include <cstdint>
 #include <string>
-#include <sstream>
-
-#include "nbt.hpp"
+#include <iostream>
 
 struct u128 {
     uint64_t most;
@@ -52,9 +50,9 @@ struct Position
     constexpr Position operator-(value_type i) const;
 
     constexpr bool operator==(const Position &other) const;
-
-    std::ostream &operator<<(std::ostream &os) const;
 };
+
+std::ostream &operator<<(std::ostream &os, const Position &pos);
 
 struct Position2D
 {
@@ -85,15 +83,17 @@ struct Position2D
     constexpr Position2D operator-(const value_type &i) const;
 
     constexpr bool operator==(const Position2D &other) const;
-
-    std::ostream &operator<<(std::ostream &os) const;
 };
+
+std::ostream &operator<<(std::ostream &os, const Position2D &pos);
 
 struct Rotation
 {
     float yaw;
     float pitch;
 };
+
+std::ostream &operator<<(std::ostream &os, const Rotation &rot);
 
 // Position
 constexpr Position Position::operator*(value_type i) const


### PR DESCRIPTION
You can call the logger like this:
```cpp
LINFO("I am", " dumb"); // Multiple arguments up to 9
LINFO("I am" << "dumb"); // chain << operator, up to ...
LINFO("I ", "am" << " ", "dumb"); // You can use both at the same time

LINFO(); // Output: "File.cpp:42 Log called without any arguments !"
```
Fix #96 