### PR TITLE
Reload command

### DIFF
--- a/cubic-server/Server.cpp
+++ b/cubic-server/Server.cpp
@@ -220,14 +220,24 @@ void Server::_downloadFile(const std::string &url, const std::string &path)
 **  More details in *Reload.hpp*.
 */
 void Server::reload() {
-    _config.parse("./config.yml");
-    _maxPlayer = _config.getMaxPlayers();
-    _motd = _config.getMotd();
-    _whitelistEnabled = _config.getWhitelist();
-    _enforceWhitelist = _config.getEnforceWhitelist();
-    if (_whitelistEnabled) {
-        WhitelistHandling::Whitelist whitelistReloaded = WhitelistHandling::Whitelist();
-        _whitelist = whitelistReloaded;
+    try {
+        _config.parse("./config.yml");
+        _maxPlayer = _config.getMaxPlayers();
+        _motd = _config.getMotd();
+        _whitelistEnabled = _config.getWhitelist();
+        _enforceWhitelist = _config.getEnforceWhitelist();
+    } catch (const std::exception &e) {
+        LINFO("One reloaded file or more failed. ERROR: " << e.what());
+        return;
+    }
+    try {
+        if (_whitelistEnabled) {
+            WhitelistHandling::Whitelist whitelistReloaded = WhitelistHandling::Whitelist();
+            _whitelist = whitelistReloaded;
+        }
+    } catch (const std::exception &e) {
+        LINFO("One reloaded file or more failed. ERROR: " << e.what());
+        return;
     }
     if (_enforceWhitelist) {
         enforceWhitelistOnReload();

--- a/cubic-server/Server.cpp
+++ b/cubic-server/Server.cpp
@@ -222,7 +222,7 @@ void Server::_reloadConfig() {
     try {
         _config.parse("./config.yml");
     } catch (const std::exception &e) {
-        LINFO(e.what());
+        LERROR(e.what());
         return;
     }
     _maxPlayer = _config.getMaxPlayers();
@@ -242,7 +242,7 @@ void Server::_reloadWhitelist() {
             _whitelist = whitelistReloaded;
         }
     } catch (const std::exception &e) {
-        LINFO(e.what());
+        LERROR(e.what());
         return;
     }
     return;

--- a/cubic-server/Server.cpp
+++ b/cubic-server/Server.cpp
@@ -216,9 +216,30 @@ void Server::_downloadFile(const std::string &url, const std::string &path)
 }
 
 /*
-** If the server gets a /reload, players not on the whitelist
-** must be kicked from the server if enforce-whitelist is true
-** & the whitelist is in effect
+**  Reload the server. Used in the /reload command.
+**  More details in *Reload.hpp*.
+*/
+void Server::reload() {
+    _config.parse("./config.yml");
+    _maxPlayer = _config.getMaxPlayers();
+    _motd = _config.getMotd();
+    _whitelistEnabled = _config.getWhitelist();
+    _enforceWhitelist = _config.getEnforceWhitelist();
+    if (_whitelistEnabled) {
+        WhitelistHandling::Whitelist whitelistReloaded = WhitelistHandling::Whitelist();
+        _whitelist = whitelistReloaded;
+    }
+    if (_enforceWhitelist) {
+        enforceWhitelistOnReload();
+    }
+    /* Reload level.dat + datapacks + plugins */
+    return;
+}
+
+/*
+**  If the server gets a /reload, players not on the whitelist
+**  must be kicked from the server if enforce-whitelist is true
+**  & the whitelist is in effect
 */
 void Server::enforceWhitelistOnReload()
 {

--- a/cubic-server/Server.cpp
+++ b/cubic-server/Server.cpp
@@ -216,40 +216,54 @@ void Server::_downloadFile(const std::string &url, const std::string &path)
 }
 
 /*
-**  Reload the server. Used in the /reload command.
-**  More details in *Reload.hpp*.
+**  Reloads the config if no error within the new file
 */
-void Server::reload() {
+void reloadConfig() {
     try {
         _config.parse("./config.yml");
-        _maxPlayer = _config.getMaxPlayers();
-        _motd = _config.getMotd();
-        _whitelistEnabled = _config.getWhitelist();
-        _enforceWhitelist = _config.getEnforceWhitelist();
     } catch (const std::exception &e) {
-        LINFO("One reloaded file or more failed. ERROR: " << e.what());
+        LINFO(e.what());
         return;
     }
+    _maxPlayer = _config.getMaxPlayers();
+    _motd = _config.getMotd();
+    _whitelistEnabled = _config.getWhitelist();
+    _enforceWhitelist = _config.getEnforceWhitelist();
+    return;
+}
+
+/*
+**  Reloads the whitelist if no error within the new file
+*/
+void reloadWhitelist() {
     try {
         if (_whitelistEnabled) {
             WhitelistHandling::Whitelist whitelistReloaded = WhitelistHandling::Whitelist();
             _whitelist = whitelistReloaded;
         }
     } catch (const std::exception &e) {
-        LINFO("One reloaded file or more failed. ERROR: " << e.what());
+        LINFO(e.what());
         return;
     }
-    if (_enforceWhitelist) {
-        enforceWhitelistOnReload();
-    }
+    return;
+}
+
+/*
+**  Reloads the server. Used in the /reload command.
+**  More details in *Reload.hpp*.
+*/
+void Server::reload() {
+    reloadConfig();
+    reloadWhitelist();
+    enforceWhitelistOnReload();
     /* Reload level.dat + datapacks + plugins */
     return;
 }
 
 /*
 **  If the server gets a /reload, players not on the whitelist
-**  must be kicked from the server if enforce-whitelist is true
-**  & the whitelist is in effect
+**  must be kicked out from the server if enforce-whitelist is
+**   true & the whitelist is in effect
 */
 void Server::enforceWhitelistOnReload()
 {

--- a/cubic-server/Server.cpp
+++ b/cubic-server/Server.cpp
@@ -229,7 +229,6 @@ void Server::_reloadConfig() {
     _motd = _config.getMotd();
     _whitelistEnabled = _config.getWhitelist();
     _enforceWhitelist = _config.getEnforceWhitelist();
-    return;
 }
 
 /*
@@ -243,9 +242,7 @@ void Server::_reloadWhitelist() {
         }
     } catch (const std::exception &e) {
         LERROR(e.what());
-        return;
     }
-    return;
 }
 
 /*
@@ -256,8 +253,7 @@ void Server::reload() {
     _reloadConfig();
     _reloadWhitelist();
     _enforceWhitelistOnReload();
-    /* Reload level.dat + datapacks + plugins */
-    return;
+    /* Reload datapacks + plugins */
 }
 
 /*

--- a/cubic-server/Server.cpp
+++ b/cubic-server/Server.cpp
@@ -218,7 +218,7 @@ void Server::_downloadFile(const std::string &url, const std::string &path)
 /*
 **  Reloads the config if no error within the new file
 */
-void reloadConfig() {
+void Server::_reloadConfig() {
     try {
         _config.parse("./config.yml");
     } catch (const std::exception &e) {
@@ -235,7 +235,7 @@ void reloadConfig() {
 /*
 **  Reloads the whitelist if no error within the new file
 */
-void reloadWhitelist() {
+void Server::_reloadWhitelist() {
     try {
         if (_whitelistEnabled) {
             WhitelistHandling::Whitelist whitelistReloaded = WhitelistHandling::Whitelist();
@@ -253,9 +253,9 @@ void reloadWhitelist() {
 **  More details in *Reload.hpp*.
 */
 void Server::reload() {
-    reloadConfig();
-    reloadWhitelist();
-    enforceWhitelistOnReload();
+    _reloadConfig();
+    _reloadWhitelist();
+    _enforceWhitelistOnReload();
     /* Reload level.dat + datapacks + plugins */
     return;
 }
@@ -265,7 +265,7 @@ void Server::reload() {
 **  must be kicked out from the server if enforce-whitelist is
 **   true & the whitelist is in effect
 */
-void Server::enforceWhitelistOnReload()
+void Server::_enforceWhitelistOnReload()
 {
     if (_whitelistEnabled && _enforceWhitelist) {
         for (auto &client : _clients) {

--- a/cubic-server/Server.hpp
+++ b/cubic-server/Server.hpp
@@ -48,8 +48,6 @@ public:
 
     void reload();
 
-    void enforceWhitelistOnReload();
-
     const Configuration::ConfigHandler &getConfig() const { return _config; }
 
     const WhitelistHandling::Whitelist &getWhitelist() const { return _whitelist; }
@@ -86,6 +84,9 @@ private:
     void _acceptLoop();
     void _stop();
     void _downloadFile(const std::string &url, const std::string &path);
+    void _reloadWhitelist();
+    void _reloadConfig();
+    void _enforceWhitelistOnReload();
 
 private:
     std::string _host;

--- a/cubic-server/Server.hpp
+++ b/cubic-server/Server.hpp
@@ -46,6 +46,8 @@ public:
 
     void stop();
 
+    void reload();
+
     void enforceWhitelistOnReload();
 
     const Configuration::ConfigHandler &getConfig() const { return _config; }
@@ -104,8 +106,15 @@ private:
     WhitelistHandling::Whitelist _whitelist;
     std::unordered_map<std::string_view, WorldGroup *> _worldGroups;
     std::vector<CommandBase *> _commands = {
-        new command_parser::Help,      new command_parser::QuestionMark, new command_parser::Stop, new command_parser::Seed,
-        new command_parser::DumpChunk, new command_parser::Log,          new command_parser::Op,   new command_parser::Deop,
+        new command_parser::Help,
+        new command_parser::QuestionMark,
+        new command_parser::Stop,
+        new command_parser::Seed,
+        new command_parser::DumpChunk,
+        new command_parser::Log,
+        new command_parser::Op,
+        new command_parser::Deop,
+        new command_parser::Reload,
     };
     Blocks::GlobalPalette _globalPalette;
     Items::ItemConverter _itemConverter;

--- a/cubic-server/allCommands.hpp
+++ b/cubic-server/allCommands.hpp
@@ -4,5 +4,6 @@
 #include "command_parser/commands/Log.hpp"
 #include "command_parser/commands/Op.hpp"
 #include "command_parser/commands/QuestionMark.hpp"
+#include "command_parser/commands/Reload.hpp"
 #include "command_parser/commands/Seed.hpp"
 #include "command_parser/commands/Stop.hpp"

--- a/cubic-server/command_parser/commands/CMakeLists.txt
+++ b/cubic-server/command_parser/commands/CMakeLists.txt
@@ -1,19 +1,21 @@
 target_sources (${CMAKE_PROJECT_NAME} PRIVATE
     CommandBase.hpp
-    Help.hpp
-    Help.cpp
-    QuestionMark.hpp
-    QuestionMark.cpp
-    Stop.hpp
-    Stop.cpp
-    Seed.hpp
-    Seed.cpp
-    DumpChunk.hpp
-    DumpChunk.cpp
-    Log.hpp
-    Log.cpp
-    Op.hpp
-    Op.cpp
     Deop.hpp
     Deop.cpp
+    DumpChunk.cpp
+    DumpChunk.hpp
+    Help.cpp
+    Help.hpp
+    Log.cpp
+    Log.hpp
+    Op.hpp
+    Op.cpp
+    QuestionMark.cpp
+    QuestionMark.hpp
+    Reload.cpp
+    Reload.hpp
+    Seed.cpp
+    Seed.hpp
+    Stop.cpp
+    Stop.hpp
 )

--- a/cubic-server/command_parser/commands/Reload.cpp
+++ b/cubic-server/command_parser/commands/Reload.cpp
@@ -1,9 +1,26 @@
 #include "Reload.hpp"
+#include "Server.hpp"
 
-Reload::Reload()
-{
+void command_parser::Reload::autocomplete(std::vector<std::string>& args, Player *invoker) const {
+    if (invoker)
+        return;
+    else
+        LINFO("autocomplete reload");
 }
 
-Reload::~Reload()
-{
+void command_parser::Reload::execute(std::vector<std::string>& args, Player *invoker) const {
+    if (invoker) {
+        return;
+    } else {
+        Server::getInstance()->reload();
+        LINFO("Successfully reloaded loot tables, advancements and functions");
+    }
+}
+
+void command_parser::Reload::help(std::vector<std::string>& args, Player *invoker) const {
+    if (invoker) {
+        // if (invoker->isOperator()) // TODO: uncomment this when permissions are implemented
+            // invoker->sendPlayerChatMessage("/reload"); // TODO: Change this to the correct packet (gl @STMiki)
+    } else
+        LINFO("/reload");
 }

--- a/cubic-server/command_parser/commands/Reload.cpp
+++ b/cubic-server/command_parser/commands/Reload.cpp
@@ -1,0 +1,9 @@
+#include "Reload.hpp"
+
+Reload::Reload()
+{
+}
+
+Reload::~Reload()
+{
+}

--- a/cubic-server/command_parser/commands/Reload.cpp
+++ b/cubic-server/command_parser/commands/Reload.cpp
@@ -10,7 +10,10 @@ void command_parser::Reload::autocomplete(std::vector<std::string>& args, Player
 
 void command_parser::Reload::execute(std::vector<std::string>& args, Player *invoker) const {
     if (invoker) {
-        return;
+        if (invoker->isOperator()) {
+            Server::getInstance()->reload();
+            LINFO("Successfully reloaded loot tables, advancements and functions");
+        }
     } else {
         Server::getInstance()->reload();
         LINFO("Successfully reloaded loot tables, advancements and functions");

--- a/cubic-server/command_parser/commands/Reload.hpp
+++ b/cubic-server/command_parser/commands/Reload.hpp
@@ -1,13 +1,40 @@
 #ifndef RELOAD_HPP_
 #define RELOAD_HPP_
 
-class Reload {
-    public:
-        Reload();
-        ~Reload();
+#include "CommandBase.hpp"
 
-    protected:
-    private:
+/*
+**  Reload command always success and displays
+**  "Successfully reloaded loot tables, advancements
+**  and functions".
+**
+**  If one of the reloaded file contain an error,
+**  the file is skipped and the last working version
+**  of the file is loaded instead.
+**  If no file was loaded before, the file containing
+**  the error is skipped without being replaced.
+**
+**  The command is supposed to reload the server
+**  without stopping it nor affecting the players
+**  except if the whitelist is to be enforced.
+**
+**  Files to be reloaded:
+**
+**   - config.yml
+**   - whitelist.txt
+**   - .minecraft/saves/(world)/datapacks
+**   - level.dat
+**   - plugins
+*/
+
+namespace command_parser {
+struct Reload : public CommandBase {
+    Reload() : CommandBase("reload", "/reload", true) {}
+
+    void autocomplete(std::vector<std::string>& args, Player *invoker) const override;
+    void execute(std::vector<std::string>& args, Player *invoker) const override;
+    void help(std::vector<std::string>& args, Player *invoker) const override;
 };
+}
 
 #endif /* !RELOAD_HPP_ */

--- a/cubic-server/command_parser/commands/Reload.hpp
+++ b/cubic-server/command_parser/commands/Reload.hpp
@@ -1,0 +1,13 @@
+#ifndef RELOAD_HPP_
+#define RELOAD_HPP_
+
+class Reload {
+    public:
+        Reload();
+        ~Reload();
+
+    protected:
+    private:
+};
+
+#endif /* !RELOAD_HPP_ */

--- a/cubic-server/command_parser/commands/Reload.hpp
+++ b/cubic-server/command_parser/commands/Reload.hpp
@@ -23,7 +23,6 @@
 **   - config.yml
 **   - whitelist.txt
 **   - .minecraft/saves/(world)/datapacks
-**   - level.dat
 **   - plugins
 */
 

--- a/cubic-server/configuration/ConfigHandler.cpp
+++ b/cubic-server/configuration/ConfigHandler.cpp
@@ -40,8 +40,8 @@ void ConfigHandler::parse(const std::string &path)
         _whitelist = _baseNode["general"]["whitelist"].as<bool>();
         _enforceWhitelist = _baseNode["general"]["enforce-whitelist"].as<bool>();
     } catch (const std::exception &e) {
-        LERROR("Config parsing failed, exiting now!" << std::endl << e.what());
-        exit(1); // TODO: Use an exception
+        LERROR("config parsing failed : " << e.what());
+        throw std::runtime_error("config parsing failed");
     }
 }
 

--- a/cubic-server/whitelist/Whitelist.cpp
+++ b/cubic-server/whitelist/Whitelist.cpp
@@ -20,25 +20,6 @@ std::string u128_to_uuidString(u128 u)
     return str;
 }
 
-// u128 uuidString_to_u128(std::string str)
-// {
-//     std::stringstream sstr;
-//     std::istringstream isstr;
-//     u128 u;
-//     uint64_t u_most;
-//     uint64_t u_least;
-
-//     str.erase(std::remove(str.begin(), str.end(), '-'), str.end());
-//     isstr.str(str);
-//     isstr >> std::hex >> sstr;
-//     u_most = strtoull(sstr.str().substr(0, 16));
-//     u_least = strtoull(sstr.str().substr(15, 16));
-//     u.most = u_most;
-//     u.least = u_least;
-
-//     return u;
-// }
-
 namespace WhitelistHandling {
 static void defaultWhitelistContent(const std::string &path)
 {
@@ -52,7 +33,12 @@ static void defaultWhitelistContent(const std::string &path)
 void Whitelist::_parseWhitelist(const std::string &path)
 {
     std::ifstream whitelistFile(path);
-    _whitelistData = nlohmann::json::parse(whitelistFile);
+    try {
+        _whitelistData = nlohmann::json::parse(whitelistFile);
+    } catch(const std::exception& e) {
+        LERROR("whitelist parsing failed : " << e.what());
+        throw std::runtime_error("whitelist parsing failed");
+    }
     whitelistFile.close();
 }
 

--- a/cubic-server/whitelist/Whitelist.hpp
+++ b/cubic-server/whitelist/Whitelist.hpp
@@ -2,6 +2,7 @@
 #define WHITELIST_HPP_
 
 #include <string>
+#include "logging/Logger.hpp"
 
 #include "nlohmann/json.hpp"
 #include "types.hpp"


### PR DESCRIPTION
Reload command always success.

If one of the reloaded file contain an error, the file is skipped and the last working version of the file is loaded instead.
If no file was loaded before, the file containing the error is skipped without being replaced.

The command is supposed to reload the server without stopping it nor affecting the players except if the whitelist is to be enforced.

Files to be reloaded:
 - config.yml
 - whitelist.txt
 - .minecraft/saves/(world)/datapacks
 - plugins