### PR TITLE
Fix test in Release mode and control what boost download/compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,11 @@ if (CMAKE_BUILD_TYPE MATCHES Release)
     endif()
 endif()
 
-set(BOOST_INCLUDE_LIBRARIES asio system container lockfree circular_buffer)
-set(BOOST_ENABLE_CMAKE ON)
+# Disable building of mbedtls programs
+set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
+set(ENABLE_TESTING OFF)
 
+include(boost.cmake)
 include(FetchContent)
 
 set(FETCHCONTENT_QUIET OFF)
@@ -106,6 +108,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/boostorg/boost.git
     GIT_TAG boost-1.82.0
     GIT_PROGRESS TRUE
+    GIT_SUBMODULES ${BOOST_REQD_SUBMODULES}
     GIT_SHALLOW TRUE
 )
 
@@ -162,6 +165,7 @@ if(GTEST) # if the flag GTEST is true
         googletest
     )
 
+    set(ENABLE_TESTING ON CACHE BOOL "" FORCE)
     enable_testing()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,12 @@ endif()
 
 # Disable building of mbedtls programs
 set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
-set(ENABLE_TESTING OFF)
-
-include(boost.cmake)
-include(FetchContent)
+set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 
 set(FETCHCONTENT_QUIET OFF)
+
+include(FetchContent)
+include(boost.cmake)
 
 FetchContent_Declare(
     yaml-cpp
@@ -104,15 +104,6 @@ FetchContent_Declare(
 )
 
 FetchContent_Declare(
-    boost
-    GIT_REPOSITORY https://github.com/boostorg/boost.git
-    GIT_TAG boost-1.82.0
-    GIT_PROGRESS TRUE
-    GIT_SUBMODULES ${BOOST_REQD_SUBMODULES}
-    GIT_SHALLOW TRUE
-)
-
-FetchContent_Declare(
     mbedtls
     GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls.git
     GIT_TAG v3.4.0
@@ -131,7 +122,6 @@ FetchContent_MakeAvailable(
     nbt
     spdlog
     mbedtls
-    boost
     plugin-interface
 )
 
@@ -220,11 +210,11 @@ target_link_libraries (${CMAKE_PROJECT_NAME} PRIVATE
     spdlog::spdlog
     CURL::libcurl
     $<$<BOOL:${MINGW}>:ws2_32>
-    Boost::asio
-    Boost::container
-    Boost::system
-    Boost::lockfree
-    Boost::circular_buffer
+    $<$<NOT:$<BOOL:${Boost_FOUND}>>:Boost::asio>
+    $<$<NOT:$<BOOL:${Boost_FOUND}>>:Boost::container>
+    $<$<NOT:$<BOOL:${Boost_FOUND}>>:Boost::system>
+    $<$<NOT:$<BOOL:${Boost_FOUND}>>:Boost::lockfree>
+    $<$<NOT:$<BOOL:${Boost_FOUND}>>:Boost::circular_buffer>
     plugin-interface
 )
 

--- a/boost.cmake
+++ b/boost.cmake
@@ -1,80 +1,100 @@
-
-# Build only the required boost libraries
-list(APPEND BOOST_REQD_SUBMODULES
-    # Asio
-    "asio"
-        "align"
-        "array"
-        "assert"
-        "bind"
-            "chrono"
-                "typeof"
-                "ratio"
-                    "rational"
-        "config"
-        "core"
-        "coroutine"
-            "context"
-                "pool"
-        "date_time"
-            "tokenizer"
-            "numeric/conversion"
-            "lexical_cast"
-            "algorithm"
-                "unordered"
-                "range"
-                "exception"
-        "function"
-        "regex"
-        "smart_ptr"
-        "system"
-        "throw_exception"
-        "type_traits"
-        "utility"
-            "io"
-
-    # Container
-    "container"
-        "intrusive"
-            "container_hash"
-                "describe"
-        "move"
-        "static_assert"
-
-    # System
-    "system"
-        "variant2"
-            "mp11"
-        "winapi"
-
-    # Lock Free
-    "lockfree"
-        "atomic"
-            "preprocessor"
-        "integer"
-        "iterator"
-            "detail"
-            "conversion"
-        "mpl"
-        "parameter"
-            "optional"
-            "fusion"
-                "functional"
-                "function_types"
-        "predef"
-        "tuple"
-    "lockfree"
-
-    # Circular Buffer
-    "circular_buffer"
-        "concept_check"
-)
-list(TRANSFORM BOOST_REQD_SUBMODULES PREPEND "libs/")
-
-list(APPEND BOOST_REQD_SUBMODULES
-    "tools/build"
-    "tools/cmake"
-)
+set(BOOST_VERSION 1.78.0)
 
 set(BOOST_INCLUDE_LIBRARIES asio system container lockfree circular_buffer)
 set(BOOST_ENABLE_CMAKE ON)
+
+find_package(Boost ${BOOST_VERSION} COMPONENTS system container)
+
+if (Boost_FOUND)
+    message(STATUS "Boost found, using system version ${Boost_VERSION}")
+else()
+    message(STATUS "Boost not found, downloading...")
+    # Build only the required boost libraries
+    list(APPEND BOOST_REQD_SUBMODULES
+        # Asio
+        "asio"
+            "align"
+            "array"
+            "assert"
+            "bind"
+                "chrono"
+                    "typeof"
+                    "ratio"
+                        "rational"
+            "config"
+            "core"
+            "coroutine"
+                "context"
+                    "pool"
+            "date_time"
+                "tokenizer"
+                "numeric/conversion"
+                "lexical_cast"
+                "algorithm"
+                    "unordered"
+                    "range"
+                    "exception"
+            "function"
+                "type_index"
+            "regex"
+            "smart_ptr"
+            "system"
+            "throw_exception"
+            "type_traits"
+            "utility"
+                "io"
+
+        # Container
+        "container"
+            "intrusive"
+                "container_hash"
+                    "describe"
+            "move"
+            "static_assert"
+
+        # System
+        "system"
+            "variant2"
+                "mp11"
+            "winapi"
+
+        # Lock Free
+        "lockfree"
+            "atomic"
+                "preprocessor"
+            "integer"
+            "iterator"
+                "detail"
+                "conversion"
+            "mpl"
+            "parameter"
+                "optional"
+                "fusion"
+                    "functional"
+                    "function_types"
+            "predef"
+            "tuple"
+        "lockfree"
+
+        # Circular Buffer
+        "circular_buffer"
+            "concept_check"
+    )
+    list(TRANSFORM BOOST_REQD_SUBMODULES PREPEND "libs/")
+
+    list(APPEND BOOST_REQD_SUBMODULES
+        "tools/build"
+        "tools/cmake"
+    )
+
+    FetchContent_Declare(
+        boost
+        GIT_REPOSITORY https://github.com/boostorg/boost.git
+        GIT_TAG boost-${BOOST_VERSION}
+        GIT_PROGRESS TRUE
+        GIT_SUBMODULES ${BOOST_REQD_SUBMODULES}
+        GIT_SHALLOW TRUE
+    )
+
+    FetchContent_MakeAvailable(boost)
+endif()

--- a/boost.cmake
+++ b/boost.cmake
@@ -1,0 +1,80 @@
+
+# Build only the required boost libraries
+list(APPEND BOOST_REQD_SUBMODULES
+    # Asio
+    "asio"
+        "align"
+        "array"
+        "assert"
+        "bind"
+            "chrono"
+                "typeof"
+                "ratio"
+                    "rational"
+        "config"
+        "core"
+        "coroutine"
+            "context"
+                "pool"
+        "date_time"
+            "tokenizer"
+            "numeric/conversion"
+            "lexical_cast"
+            "algorithm"
+                "unordered"
+                "range"
+                "exception"
+        "function"
+        "regex"
+        "smart_ptr"
+        "system"
+        "throw_exception"
+        "type_traits"
+        "utility"
+            "io"
+
+    # Container
+    "container"
+        "intrusive"
+            "container_hash"
+                "describe"
+        "move"
+        "static_assert"
+
+    # System
+    "system"
+        "variant2"
+            "mp11"
+        "winapi"
+
+    # Lock Free
+    "lockfree"
+        "atomic"
+            "preprocessor"
+        "integer"
+        "iterator"
+            "detail"
+            "conversion"
+        "mpl"
+        "parameter"
+            "optional"
+            "fusion"
+                "functional"
+                "function_types"
+        "predef"
+        "tuple"
+    "lockfree"
+
+    # Circular Buffer
+    "circular_buffer"
+        "concept_check"
+)
+list(TRANSFORM BOOST_REQD_SUBMODULES PREPEND "libs/")
+
+list(APPEND BOOST_REQD_SUBMODULES
+    "tools/build"
+    "tools/cmake"
+)
+
+set(BOOST_INCLUDE_LIBRARIES asio system container lockfree circular_buffer)
+set(BOOST_ENABLE_CMAKE ON)


### PR DESCRIPTION
- Test only compile if GTEST is enabled
- Restrict what library boost downloads/compile