### PR TITLE
Pickup an item in inventory

### DIFF
--- a/cubic-server/protocol/ClientPackets.hpp
+++ b/cubic-server/protocol/ClientPackets.hpp
@@ -75,6 +75,7 @@ enum class ClientPacketID : int32_t {
     SoundEffect = 0x5E,
     StopSound = 0x5F,
     SystemChatMessage = 0x60,
+    PickupItem = 0x63,
     TeleportEntity = 0x64,
     UpdateAdvancements = 0x65,
     UpdateAttributes = 0x66,
@@ -740,6 +741,14 @@ struct StopSound {
     std::string sound;
 };
 std::unique_ptr<std::vector<uint8_t>> createStopSound(const StopSound &);
+
+struct PickupItem {
+    int32_t collectedEntityId;
+    int32_t collectorEntityId;
+    int32_t pickupItemCount;
+
+};
+std::unique_ptr<std::vector<uint8_t>> createPickupItem(const PickupItem &);
 
 struct SystemChatMessage {
     std::string JSONData;


### PR DESCRIPTION
- [ ] Implementation of the “Pickup item” packet
- [ ] Send the packet to a player that is in the item's collection area, checking at each set_player_position
- [ ] Destroy picked up entity
- [ ] Add item to player/entity inventory