### PR TITLE
Fix ore generation

### DIFF
--- a/cubic-server/generation/features/underground/OreVein.cpp
+++ b/cubic-server/generation/features/underground/OreVein.cpp
@@ -125,8 +125,9 @@ void OreVein::createBlob(const BlockId &blockID, const int spawnSize, const Posi
                 customSkipRate =
                     abs((((blobCenter.x - x) % SECTION_WIDTH) ^ 2) + (((blobCenter.y - y) % SECTION_WIDTH) ^ 2) + (((blobCenter.z - z) % SECTION_WIDTH) ^ 2) % SECTION_WIDTH);
                 auto block = _chunk.getBlock({x, y, z});
+                // TODO: When the generation will support decoration, block = stone has to be changed so every "stone" block is taken into account
                 if ((x - pos.x < r && z - pos.z < r) && r / 2 > customSkipRate && nb < nbOfBlocksInBlob &&
-                    (block != Blocks::Air::toProtocol() && block != Blocks::Bedrock::toProtocol()) && y > CHUNK_HEIGHT_MIN) {
+                    (block == Blocks::Stone::toProtocol()) && (y > CHUNK_HEIGHT_MIN && y < CHUNK_HEIGHT_MAX)) {
                     _chunk.updateBlock({x, y, z}, blockID);
                     nb++;
                 }

--- a/cubic-server/generation/features/underground/OreVein.cpp
+++ b/cubic-server/generation/features/underground/OreVein.cpp
@@ -126,8 +126,8 @@ void OreVein::createBlob(const BlockId &blockID, const int spawnSize, const Posi
                     abs((((blobCenter.x - x) % SECTION_WIDTH) ^ 2) + (((blobCenter.y - y) % SECTION_WIDTH) ^ 2) + (((blobCenter.z - z) % SECTION_WIDTH) ^ 2) % SECTION_WIDTH);
                 auto block = _chunk.getBlock({x, y, z});
                 // TODO: When the generation will support decoration, block = stone has to be changed so every "stone" block is taken into account
-                if ((x - pos.x < r && z - pos.z < r) && r / 2 > customSkipRate && nb < nbOfBlocksInBlob &&
-                    (block == Blocks::Stone::toProtocol()) && (y > CHUNK_HEIGHT_MIN && y < CHUNK_HEIGHT_MAX)) {
+                if ((x - pos.x < r && z - pos.z < r) && r / 2 > customSkipRate && nb < nbOfBlocksInBlob && (block == Blocks::Stone::toProtocol()) &&
+                    (y > CHUNK_HEIGHT_MIN && y < CHUNK_HEIGHT_MAX)) {
                     _chunk.updateBlock({x, y, z}, blockID);
                     nb++;
                 }

--- a/cubic-server/world_storage/ChunkColumn.cpp
+++ b/cubic-server/world_storage/ChunkColumn.cpp
@@ -482,19 +482,19 @@ void ChunkColumn::_generateRawGeneration(generation::Generator &generator)
 void ChunkColumn::_generateLakes(UNUSED generation::Generator &generator)
 {
     std::lock_guard<std::mutex> _(this->_generationLock);
-    // int waterLevel = 86;
+    int waterLevel = 86;
 
     // TODO: improve this to fill caves
     // generate water
-    // for (int z = 0; z < SECTION_WIDTH; z++) {
-    //     for (int x = 0; x < SECTION_WIDTH; x++) {
-    //         for (int y = waterLevel; 0 < y; y--) {
-    //             if (getBlock({x, y, z}) == 1)
-    //                 break;
-    //             updateBlock({x, y, z}, Blocks::Water::toProtocol(Blocks::Water::Properties::Level::ZERO));
-    //         }
-    //     }
-    // }
+    for (int z = 0; z < SECTION_WIDTH; z++) {
+        for (int x = 0; x < SECTION_WIDTH; x++) {
+            for (int y = waterLevel; 0 < y; y--) {
+                if (getBlock({x, y, z}) == 1)
+                    break;
+                updateBlock({x, y, z}, Blocks::Water::toProtocol(Blocks::Water::Properties::Level::ZERO));
+            }
+        }
+    }
     _currentState = GenerationState::LAKES;
 }
 


### PR DESCRIPTION
Fix the generation in dirt blocks.
/!\ This fix will have to be changed when the world generation will take into account other blocks than stone as decoration.