### PR TITLE
Fix negative coordinate blocs

### DIFF
--- a/cubic-server/Dimension.cpp
+++ b/cubic-server/Dimension.cpp
@@ -334,15 +334,8 @@ void Dimension::updateBlock(Position position, int32_t id)
     LDEBUG("Dimension block update {} -> {}", position, id);
     auto &chunk = this->_level.getChunkColumnFromBlockPos(position.x, position.z);
 
-    // Weird ass modulo to get the correct block position in the chunk
-    auto x = position.x % 16;
-    auto z = position.z % 16;
-    if (x < 0)
-        x += 16;
-    if (z < 0)
-        z += 16;
-
-    chunk.updateBlock({x, position.y, z}, id);
+    auto chunkPosition = world_storage::convertPositionToChunkPosition(position);
+    chunk.updateBlock(chunkPosition, id);
     std::lock_guard _(_playersMutex);
     for (auto player : _players) {
         player->sendBlockUpdate({position, id});

--- a/cubic-server/Dimension.hpp
+++ b/cubic-server/Dimension.hpp
@@ -145,7 +145,7 @@ public:
      * @param pos The position of the block
      * @return BlockId The block ID
      */
-    virtual BlockId getBlock(const Position &pos) const { return getLevel().getChunkColumnFromBlockPos(pos.x, pos.z).getBlock(pos); }
+    virtual BlockId getBlock(const Position &pos) const { return getLevel().getChunkColumnFromBlockPos(pos.x, pos.z).getBlock(world_storage::convertPositionToChunkPosition(pos)); }
 
     /**
      * @brief Get the tps of the dimension

--- a/cubic-server/world_storage/ChunkColumn.hpp
+++ b/cubic-server/world_storage/ChunkColumn.hpp
@@ -16,6 +16,18 @@ class Dimension;
 
 namespace world_storage {
 
+// Weird ass modulo to get the correct block position in the chunk
+inline Position convertPositionToChunkPosition(const Position &position)
+{
+    auto x = position.x % 16;
+    auto z = position.z % 16;
+    if (x < 0)
+        x += 16;
+    if (z < 0)
+        z += 16;
+    return {x, position.y, z};
+}
+
 // Heightmap
 constexpr int HEIGHTMAP_BITS = bitsNeeded(CHUNK_HEIGHT + 1);
 constexpr int HEIGHTMAP_ARRAY_SIZE = (SECTION_2D_SIZE * HEIGHTMAP_BITS / 64) + ((SECTION_2D_SIZE * HEIGHTMAP_BITS % 64) != 0);


### PR DESCRIPTION
Getting blocks from the world storage at negative would result in incorrect ids being fetched, due to missing conversion from world position to chunk position.

A cleaner fix would be to implement a `ChunkPosition` type, which would perform the conversion automatically, and use this new type for every operation involving chunk coordinates.